### PR TITLE
ci(build): bump actions/upload-artifact v3 -> v4 (GitHub deprecation hard-fail)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
           agree-to-terms: true
 
       - name: Upload metanorma artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: draft
           path: site


### PR DESCRIPTION
GitHub is hard-failing runs pinning `actions/upload-artifact@v3` per GitHub's [deprecation schedule](https://github.com/actions/upload-artifact#v3-deprecation) ("automatically failed because it uses a deprecated version").

Bumps `v3 → v4` on this workflow. Single-upload, single-job — no matrix name-collision risk, no `download-artifact` pair.

v4 migration check for this file:

- Same-name double upload: n/a (single upload)
- `overwrite: true` needed: n/a
- `download-artifact@v4` pair: n/a

🤖
